### PR TITLE
fix text section indices

### DIFF
--- a/backend/src/parsers/TextParser.test.ts
+++ b/backend/src/parsers/TextParser.test.ts
@@ -1,0 +1,24 @@
+import { TextParser } from './TextParser';
+
+const parser = new TextParser();
+
+function extract(raw: string) {
+  // @ts-ignore accessing protected method for testing
+  const cleaned = (parser as any).cleanText(raw);
+  // @ts-ignore accessing private method for testing
+  return (parser as any).extractSections(cleaned, {});
+}
+
+describe('TextParser extractSections', () => {
+  test('maintains correct indices for various newline styles', () => {
+    const raw = 'Line1\r\n\r\nLine2\n\nLine3';
+    const sections = extract(raw);
+    expect(sections).toHaveLength(3);
+    expect(sections[0].startChar).toBe(0);
+    expect(sections[0].endChar).toBe(5);
+    expect(sections[1].startChar).toBe(7);
+    expect(sections[1].endChar).toBe(12);
+    expect(sections[2].startChar).toBe(14);
+    expect(sections[2].endChar).toBe(19);
+  });
+});

--- a/backend/src/parsers/TextParser.ts
+++ b/backend/src/parsers/TextParser.ts
@@ -64,20 +64,51 @@ export class TextParser extends BaseParser {
    */
   private extractSections(text: string, config: ParseConfig): ParsedSection[] {
     const sections: ParsedSection[] = [];
-    
-    // 按空行分段
-    const paragraphs = text.split(/\n\s*\n/).filter(p => p.trim().length > 0);
-    
+
+    const separatorRegex = /\n\s*\n/g;
+    let match: RegExpExecArray | null;
     let currentChar = 0;
-    
-    paragraphs.forEach((paragraph, index) => {
+    let index = 0;
+
+    while ((match = separatorRegex.exec(text)) !== null) {
+      const paragraph = text.slice(currentChar, match.index);
       const trimmedParagraph = paragraph.trim();
+
+      if (trimmedParagraph.length > 0) {
+        const startChar = currentChar;
+        const endChar = startChar + trimmedParagraph.length;
+        const isTitle = this.detectTitle(trimmedParagraph, config);
+
+        const section: ParsedSection = {
+          path: (index + 1).toString(),
+          text: trimmedParagraph,
+          level: isTitle ? 1 : 2,
+          startChar,
+          endChar,
+          type: isTitle ? SectionType.TITLE : SectionType.PARAGRAPH,
+          confidence: 0.8,
+          metadata: {
+            paragraphIndex: index,
+            wordCount: trimmedParagraph.split(/\s+/).length
+          }
+        };
+        if (isTitle) {
+          section.title = trimmedParagraph;
+        }
+        sections.push(section);
+        index++;
+      }
+
+      currentChar = match.index + match[0].length;
+    }
+
+    const lastParagraph = text.slice(currentChar);
+    if (lastParagraph.trim().length > 0) {
+      const trimmedParagraph = lastParagraph.trim();
       const startChar = currentChar;
       const endChar = startChar + trimmedParagraph.length;
-      
-      // 检测是否为标题
       const isTitle = this.detectTitle(trimmedParagraph, config);
-      
+
       const section: ParsedSection = {
         path: (index + 1).toString(),
         text: trimmedParagraph,
@@ -95,10 +126,8 @@ export class TextParser extends BaseParser {
         section.title = trimmedParagraph;
       }
       sections.push(section);
-      
-      currentChar = endChar + 2; // 包括换行符
-    });
-    
+    }
+
     return sections;
   }
 


### PR DESCRIPTION
## Summary
- correct TextParser section indexing by using actual newline separator length
- add unit test covering mixed newline combinations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689534d04df48321a6a3d09ac989d405